### PR TITLE
fix: nginx routing to dshackle upstreams

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
 
   dshackle:
     container_name: dshackle
-    image: emeraldpay/dshackle:0.13
+    image: emeraldpay/dshackle:0.14
     restart: unless-stopped
     volumes:
       - ./dshackle_conf:/etc/dshackle

--- a/dshackle_conf/beam_test.yaml
+++ b/dshackle_conf/beam_test.yaml
@@ -1,14 +1,10 @@
 upstreams:
-  - id:  beam-test-do
+  - id: beam-rpc1
     chain: ethereum-classic
-    methods:
-        enabled:
-          - name: eth_chainId
-            static: "0x3419"  # static return value
-          - name: net_version
-            static: "13337"
     options:
-        disable-validation: true
+      disable-validation: true
+    #        role: primary
+    #        priority: 20
     labels:
       provider: geth
       archive: false
@@ -16,15 +12,17 @@ upstreams:
     connection:
       ethereum:
         rpc:
-          url: "http://157.230.66.23:9650/ext/bc/2NXVLcGbemMjwyexwigxCoqn7UJ6DdeJdWNPxcWX4Y2eDem1aW/rpc"
-#        ws:
-#          url: "ws://157.230.66.23:9650/ext/bc/2NXVLcGbemMjwyexwigxCoqn7UJ6DdeJdWNPxcWX4Y2eDem1aW/rpc"
+          url: "http://157.230.66.23:9650/ext/bc/y97omoP2cSyEVfdSztQHXD9EnfnVP9YKjZwAxhUfGbLAPYT9t/rpc"
+    #          ws: "ws://157.230.66.23:9650/ext/bc/y97omoP2cSyEVfdSztQHXD9EnfnVP9YKjZwAxhUfGbLAPYT9t/ws"
     methods:
       enabled:
+        - name: eth_chainId
+          static: "0x3419" # static return value
+        - name: net_version
+          static: "13337"
         - name: eth_accounts
         - name: eth_blockNumber
         - name: eth_call
-        - name: eth_chainId
         - name: eth_coinbase
         - name: eth_compileLLL
         - name: eth_compileSerpent
@@ -70,37 +68,36 @@ upstreams:
         - name: eth_unsubscribe
         - name: net_listening
         - name: net_peerCount
-        - name: net_version
         - name: txpool_content
         - name: txpool_inspect
         - name: txpool_status
         - name: web3_clientVersion
         - name: web3_sha3
 
-  - id:  beam-test-avax
+  - id: beam-rpc2
     chain: ethereum-classic
-    methods:
-        enabled:
-          - name: eth_chainId
-            static: "0x3419"  # static return value
-          - name: net_version
-            static: "13337"
     options:
-        disable-validation: true
+      disable-validation: true
+    #        role: secondary
+    #        priority: 10
     labels:
       provider: geth
       archive: false
-      fullnode: true
+      fullnode: false
     connection:
       ethereum:
         rpc:
-          url: "https://subnets.avax.network/beam/testnet/rpc"
+          url: "http://178.62.81.77:9650/ext/bc/y97omoP2cSyEVfdSztQHXD9EnfnVP9YKjZwAxhUfGbLAPYT9t/rpc"
+    #          ws: "ws://178.62.81.77:9650/ext/bc/y97omoP2cSyEVfdSztQHXD9EnfnVP9YKjZwAxhUfGbLAPYT9t/ws"
     methods:
       enabled:
+        - name: eth_chainId
+          static: "0x3419" # static return value
+        - name: net_version
+          static: "13337"
         - name: eth_accounts
         - name: eth_blockNumber
         - name: eth_call
-        - name: eth_chainId
         - name: eth_coinbase
         - name: eth_compileLLL
         - name: eth_compileSerpent
@@ -146,7 +143,78 @@ upstreams:
         - name: eth_unsubscribe
         - name: net_listening
         - name: net_peerCount
+        - name: txpool_content
+        - name: txpool_inspect
+        - name: txpool_status
+        - name: web3_clientVersion
+        - name: web3_sha3
+
+  - id: beam-test-avax
+    chain: ethereum-classic
+    options:
+      disable-validation: true
+    labels:
+      provider: geth
+      archive: false
+      fullnode: false
+    connection:
+      ethereum:
+        rpc:
+          url: "https://subnets.avax.network/beam/testnet/rpc"
+    methods:
+      enabled:
+        - name: eth_chainId
+          static: "0x3419" # static return value
         - name: net_version
+          static: "13337"
+        - name: eth_accounts
+        - name: eth_blockNumber
+        - name: eth_call
+        - name: eth_coinbase
+        - name: eth_compileLLL
+        - name: eth_compileSerpent
+        - name: eth_compileSolidity
+        - name: eth_estimateGas
+        - name: eth_gasPrice
+        - name: eth_getBalance
+        - name: eth_getBlockByHash
+        - name: eth_getBlockByNumber
+        - name: eth_getBlockTransactionCountByHash
+        - name: eth_getBlockTransactionCountByNumber
+        - name: eth_getCode
+        - name: eth_getCompilers
+        - name: eth_getFilterChanges
+        - name: eth_getFilterLogs
+        - name: eth_getLogs
+        - name: eth_getStorageAt
+        - name: eth_getTransactionByBlockHashAndIndex
+        - name: eth_getTransactionByBlockNumberAndIndex
+        - name: eth_getTransactionByHash
+        - name: eth_getTransactionCount
+        - name: eth_getTransactionReceipt
+        - name: eth_getUncleByBlockHashAndIndex
+        - name: eth_getUncleByBlockNumberAndIndex
+        - name: eth_getUncleCountByBlockHash
+        - name: eth_getUncleCountByBlockNumber
+        - name: eth_getWork
+        - name: eth_hashrate
+        - name: eth_mining
+        - name: eth_newBlockFilter
+        - name: eth_newFilter
+        - name: eth_newPendingTransactionFilter
+        - name: eth_protocolVersion
+        - name: eth_sendRawTransaction
+        - name: eth_sendTransaction
+        - name: eth_sign
+        - name: eth_signTransaction
+        - name: eth_submitHashrate
+        - name: eth_submitWork
+        - name: eth_subscribe
+        - name: eth_syncing
+        - name: eth_uninstallFilter
+        - name: eth_unsubscribe
+        - name: net_listening
+        - name: net_peerCount
         - name: txpool_content
         - name: txpool_inspect
         - name: txpool_status

--- a/dshackle_conf/dshackle.yaml
+++ b/dshackle_conf/dshackle.yaml
@@ -17,7 +17,7 @@ monitoring:
     port: 8081
     path: /metrics
 
-# Enabling redis database for caching, it should be running in docker container 
+# Enabling redis database for caching, it should be running in docker container
 cache:
   redis:
     enabled: true
@@ -32,26 +32,23 @@ proxy:
   tls:
     enabled: false
   routes:
-#    - id: mainnet
-#      blockchain: ethereum
-    - id: testnet
+    - id: rpc
       blockchain: ethereum-classic
-#    - id: arbitrum
-#      blockchain: matic
-#    - id: goerli
-#      blockchain: goerli
 
-# Connections to clients for various endpoints
-# Leave only those you are going to use
 cluster:
   defaults:
     - chains:
         - ethereum-classic
-#    - chains:
-#        - goerli
-#    - chains:
-#        - optimism
-#    - chains:
-#        - arbitrum
   include:
     - "beam_test.yaml"
+
+# Include dshackle logging
+# Mount the container's /var/log directory using docker-compose to access
+# logs from the host machine
+access-log:
+  enabled: true
+  filename: "/var/log/dshackle_access_log.jsonl"
+
+request-log:
+  enabled: true
+  filename: "/var/log/dshackle_request_log.jsonl"

--- a/nginx_conf/beam-testnet.meritcircle.io_location
+++ b/nginx_conf/beam-testnet.meritcircle.io_location
@@ -1,0 +1,23 @@
+	if ($request_method = 'OPTIONS') {
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+      add_header 'Access-Control-Allow-Headers' 'Content-Type';
+      add_header 'Cache-Control' 'no-cache';
+      add_header 'Connection' 'close';
+      add_header 'Content-Type' 'text/plain; charset=utf-8';
+      add_header 'Content-Length' "";
+      return 200;
+    }
+    if ($request_method = 'GET' ) {
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+      add_header 'Access-Control-Allow-Headers' 'Content-Type';
+      add_header 'Cache-Control' 'no-cache';
+      add_header 'Connection' 'close';
+      add_header 'Content-Type' 'text/plain; charset=utf-8';
+      add_header 'Content-Length' "";
+      return 200;
+    }
+    if ($request_method = 'POST') {
+      add_header 'Access-Control-Allow-Origin' '*';
+    }

--- a/nginx_conf/proxy.conf
+++ b/nginx_conf/proxy.conf
@@ -1,0 +1,7 @@
+proxy_http_version 1.1;
+proxy_buffering off;
+proxy_set_header Host $http_host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $proxy_connection;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
- System occasionally breaks when there are multiple upstream RPC nodes configured. Both role and priority flags as explained [here](https://github.com/emeraldpay/dshackle/blob/master/docs/reference-configuration.adoc#upstream-json) are not working as intended. 

- Tried using primary/standard/secondary for roles and then different values for priority but the dshackle router still forwards requests to both upstreams which messes up the nonce and causes unsyc between the RPC nodes (block height)

- Used latest dshackle docker version (0.14.0) but did not resolve the concern

- Relevant unresolved dshackle issues: [role](https://github.com/emeraldpay/dshackle/issues/251), [priority](https://github.com/emeraldpay/dshackle/issues/242)